### PR TITLE
added support for oppi://workspace urls

### DIFF
--- a/clients/apple/Oppi/App/AppNavigation.swift
+++ b/clients/apple/Oppi/App/AppNavigation.swift
@@ -37,6 +37,10 @@ final class AppNavigation {
     /// Consumed once by QuickSessionSheet, then cleared.
     var pendingQuickSessionDraft: String?
 
+    /// Pending workspace creation deep link payload. Consumed once by
+    /// WorkspaceHomeView, then cleared.
+    var pendingWorkspaceDeepLink: WorkspaceDeepLink.Payload?
+
     // MARK: - Quick Session Handoff
     //
     // These properties form a produce-once / consume-once handoff between

--- a/clients/apple/Oppi/App/OppiApp.swift
+++ b/clients/apple/Oppi/App/OppiApp.swift
@@ -88,6 +88,37 @@ enum PermissionDeepLink {
     }
 }
 
+enum WorkspaceDeepLink {
+    struct Payload: Sendable {
+        let path: String
+        let name: String?
+        let serverFingerprint: String?
+    }
+
+    static func payload(from url: URL) -> Payload? {
+        guard let scheme = url.scheme?.lowercased(), scheme == "pi" || scheme == "oppi" else {
+            return nil
+        }
+        guard url.host?.lowercased() == "workspace" else {
+            return nil
+        }
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              let queryItems = components.queryItems else {
+            return nil
+        }
+        guard let rawPath = queryItems.first(where: { $0.name == "path" })?.value,
+              !rawPath.trimmingCharacters(in: .whitespaces).isEmpty else {
+            return nil
+        }
+        let path = rawPath.removingPercentEncoding ?? rawPath
+        let rawName = queryItems.first(where: { $0.name == "name" })?.value
+        let name = rawName.flatMap { $0.removingPercentEncoding ?? $0 }?.trimmingCharacters(in: .whitespaces)
+        let nameOrNil = name.flatMap { $0.isEmpty ? nil : $0 }
+        let serverFingerprint = queryItems.first(where: { $0.name == "server" })?.value
+        return Payload(path: path, name: nameOrNil, serverFingerprint: serverFingerprint)
+    }
+}
+
 @main
 struct OppiApp: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
@@ -239,6 +270,9 @@ struct OppiApp: App {
         if handleIncomingSessionURL(url) {
             return
         }
+        if handleIncomingWorkspaceURL(url) {
+            return
+        }
         await handleIncomingInviteURL(url)
     }
 
@@ -269,6 +303,32 @@ struct OppiApp: App {
         }
 
         // Session not found locally — just open the app to workspaces tab.
+        navigation.selectedTab = .workspaces
+        return true
+    }
+
+    /// Handle `oppi://workspace/?path=<path>&name=<name>[&server=<fingerprint>]` deep links.
+    @MainActor
+    private func handleIncomingWorkspaceURL(_ url: URL) -> Bool {
+        guard let payload = WorkspaceDeepLink.payload(from: url) else { return false }
+
+        let serverCount = serverStore.servers.count
+        if serverCount == 0 {
+            connection.extensionToast = "No servers paired — pair a server first"
+            return true
+        }
+
+        if let requestedFingerprint = payload.serverFingerprint {
+            guard serverStore.server(for: requestedFingerprint) != nil else {
+                connection.extensionToast = "Server not found for this workspace link"
+                return true
+            }
+        } else if serverCount > 1 {
+            connection.extensionToast = "Workspace link requires a server (multiple servers paired)"
+            return true
+        }
+
+        navigation.pendingWorkspaceDeepLink = payload
         navigation.selectedTab = .workspaces
         return true
     }

--- a/clients/apple/Oppi/Features/Workspaces/WorkspaceCreateView.swift
+++ b/clients/apple/Oppi/Features/Workspaces/WorkspaceCreateView.swift
@@ -19,11 +19,21 @@ struct WorkspaceCreateView: View {
     init(
         server: PairedServer,
         presentation: WorkspaceCreatePresentation = .standard,
+        prefillName: String? = nil,
+        prefillPath: String? = nil,
         onCreate: ((Workspace) -> Void)? = nil
     ) {
         self.server = server
         self.presentation = presentation
         self.onCreate = onCreate
+        if let prefillPath {
+            _name = State(initialValue: prefillName ?? "")
+            _hostMount = State(initialValue: prefillPath)
+            _isHostMountFromProjectPicker = State(initialValue: false)
+            _step = State(initialValue: .configure)
+        } else if let prefillName {
+            _name = State(initialValue: prefillName)
+        }
     }
 
     @Environment(ConnectionCoordinator.self) private var coordinator

--- a/clients/apple/Oppi/Features/Workspaces/WorkspaceHomeView.swift
+++ b/clients/apple/Oppi/Features/Workspaces/WorkspaceHomeView.swift
@@ -10,12 +10,16 @@ private struct WorkspaceCreateSheetContext: Identifiable {
     let server: PairedServer
     let presentation: WorkspaceCreatePresentation
     let openWorkspaceAfterCreate: Bool
+    let prefillName: String?
+    let prefillPath: String?
 
     var id: String {
         [
             server.id,
             presentation == .guidedFirstWorkspace ? "guided" : "standard",
-            openWorkspaceAfterCreate ? "open" : "stay"
+            openWorkspaceAfterCreate ? "open" : "stay",
+            prefillName ?? "",
+            prefillPath ?? ""
         ].joined(separator: "|")
     }
 }
@@ -70,6 +74,8 @@ struct WorkspaceHomeView: View {
             WorkspaceCreateView(
                 server: context.server,
                 presentation: context.presentation,
+                prefillName: context.prefillName,
+                prefillPath: context.prefillPath,
                 onCreate: { workspace in
                     guard context.openWorkspaceAfterCreate else { return }
                     pendingCreatedWorkspaceTarget = WorkspaceNavTarget(
@@ -96,6 +102,11 @@ struct WorkspaceHomeView: View {
         .task {
             await refresh(force: false)
             triggerGuidedCreateIfNeeded()
+            consumeWorkspaceDeepLinkIfNeeded()
+        }
+        .onChange(of: navigation.pendingWorkspaceDeepLink != nil) { _, hasPending in
+            guard hasPending else { return }
+            consumeWorkspaceDeepLinkIfNeeded()
         }
         .onChange(of: navigation.selectedTab) { _, selectedTab in
             guard selectedTab == .workspaces else { return }
@@ -286,12 +297,16 @@ struct WorkspaceHomeView: View {
     private func presentCreateWorkspace(
         on server: PairedServer,
         presentation: WorkspaceCreatePresentation = .standard,
-        openWorkspaceAfterCreate: Bool = false
+        openWorkspaceAfterCreate: Bool = false,
+        prefillName: String? = nil,
+        prefillPath: String? = nil
     ) {
         createSheetContext = WorkspaceCreateSheetContext(
             server: server,
             presentation: presentation,
-            openWorkspaceAfterCreate: openWorkspaceAfterCreate
+            openWorkspaceAfterCreate: openWorkspaceAfterCreate,
+            prefillName: prefillName,
+            prefillPath: prefillPath
         )
     }
 
@@ -319,6 +334,28 @@ struct WorkspaceHomeView: View {
             on: server,
             presentation: .guidedFirstWorkspace,
             openWorkspaceAfterCreate: true
+        )
+    }
+
+    /// Consume a pending workspace creation deep link, presenting
+    /// WorkspaceCreateView with pre-filled name and path.
+    private func consumeWorkspaceDeepLinkIfNeeded() {
+        guard let payload = navigation.pendingWorkspaceDeepLink else { return }
+        navigation.pendingWorkspaceDeepLink = nil
+
+        let targetServer: PairedServer?
+        if let fingerprint = payload.serverFingerprint {
+            targetServer = serverStore.server(for: fingerprint)
+        } else {
+            targetServer = servers.first
+        }
+
+        guard let server = targetServer else { return }
+
+        presentCreateWorkspace(
+            on: server,
+            prefillName: payload.name,
+            prefillPath: payload.path
         )
     }
 


### PR DESCRIPTION
Hello!

Amazing project, I love it! 😀

This pr adds support to add new workspaces via deep links:

`oppi://workspace?path=/path/to/workspace&name=Workspace_Name`
or
`oppi://workspace?path=/path/to/workspace&name=Workspace_Name&server=fingerprintId`

When the user clicks on one of those links the "New Workspace" dialog will be opened with path / name prefilled.