### PR TITLE
fixed workspace overview layout

### DIFF
--- a/clients/apple/Oppi/Features/Workspaces/WorkspaceHomeView.swift
+++ b/clients/apple/Oppi/Features/Workspaces/WorkspaceHomeView.swift
@@ -1010,7 +1010,6 @@ private struct WorkspaceHomeRow: View {
                         .font(.headline)
                         .foregroundStyle(.themeFg)
                         .lineLimit(1)
-                        .layoutPriority(1)
 
                     if hasAttention {
                         Text("Needs attention")


### PR DESCRIPTION
Before:
<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/8ab7d879-c6bd-4fdd-b1d1-50636c30660a" />

After:
<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/6ac52e41-159d-4a17-8db1-6da74bac4895" />

(the orange is just to obscure the name of a client of mine)