### PR TITLE
deps: bump pi-ai/coding-agent/tui 0.79.10 → 0.80.2; migrate getModel/completeSimple to /compat

### DIFF
--- a/server/bun.lock
+++ b/server/bun.lock
@@ -6,9 +6,9 @@
       "name": "oppi-server",
       "dependencies": {
         "@earendil-works/gondolin": "0.12.0",
-        "@earendil-works/pi-ai": "0.79.10",
-        "@earendil-works/pi-coding-agent": "0.79.10",
-        "@earendil-works/pi-tui": "0.79.10",
+        "@earendil-works/pi-ai": "0.80.2",
+        "@earendil-works/pi-coding-agent": "0.80.2",
+        "@earendil-works/pi-tui": "0.80.2",
         "diff-match-patch": "^1.0.5",
         "typebox": "1.1.28",
         "ws": "8.21.0",
@@ -106,13 +106,13 @@
 
     "@earendil-works/gondolin-krun-runner-linux-x64": ["@earendil-works/gondolin-krun-runner-linux-x64@0.12.0", "", { "os": "linux", "cpu": "x64", "bin": { "gondolin-krun-runner": "bin/gondolin-krun-runner" } }, "sha512-RRYsgwe2r5ApKmFNy469QgwnyjAHpAs9XANdWpTd9ol4iUYOY3sX7e0xIooAKxd+ktxGI4N/xRWicwGen3D/Ow=="],
 
-    "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.79.10", "", { "dependencies": { "@earendil-works/pi-ai": "^0.79.10", "ignore": "7.0.5", "typebox": "1.1.38", "yaml": "2.9.0" } }, ""],
+    "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.80.2", "", { "dependencies": { "@earendil-works/pi-ai": "^0.80.2", "ignore": "7.0.5", "typebox": "1.1.38", "yaml": "2.9.0" } }, "sha512-BF9WPhixIFjT6Kp3Iz3H6ugkU+4AWotM8py96XE5pIK0arJbQKMWbR+dXSWWDEmR5yc/aFQODnuyowOEzMGO7Q=="],
 
-    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.79.10", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.6", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-9jR23tOl0BIUdQMn70Gr72xYBpM7Xgl9Lyv7gAnU1USfkNRuYG/f/edLl+n/Dp/RafDW3JI4DF7y/GhgkORuew=="],
+    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.80.2", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.6", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-5GNKfdrRJ4uZ5Zd9iudoXggi/BbUcKnD/xfRHtdR+7q4vWqPvfx8auFuaT+ewGBVI8K4wj87eigFQ/iCSuy9RQ=="],
 
-    "@earendil-works/pi-coding-agent": ["@earendil-works/pi-coding-agent@0.79.10", "", { "dependencies": { "@earendil-works/pi-agent-core": "^0.79.10", "@earendil-works/pi-ai": "^0.79.10", "@earendil-works/pi-tui": "^0.79.10", "@silvia-odwyer/photon-node": "0.3.4", "chalk": "5.6.2", "cross-spawn": "7.0.6", "diff": "8.0.4", "glob": "13.0.6", "highlight.js": "10.7.3", "hosted-git-info": "9.0.3", "ignore": "7.0.5", "jiti": "2.7.0", "minimatch": "10.2.5", "proper-lockfile": "4.1.2", "semver": "7.8.0", "typebox": "1.1.38", "undici": "8.5.0", "yaml": "2.9.0" }, "optionalDependencies": { "@mariozechner/clipboard": "0.3.9" }, "bin": { "pi": "dist/cli.js" } }, "sha512-YxaRhmgyDTvLDdGVbe7YzTHV80oL5mX5odg6EhGHz3w5Wu1Ix8DCw7bhtiOBLGQNFRcknia0zPmVWIj30XP1EA=="],
+    "@earendil-works/pi-coding-agent": ["@earendil-works/pi-coding-agent@0.80.2", "", { "dependencies": { "@earendil-works/pi-agent-core": "^0.80.2", "@earendil-works/pi-ai": "^0.80.2", "@earendil-works/pi-tui": "^0.80.2", "@silvia-odwyer/photon-node": "0.3.4", "chalk": "5.6.2", "cross-spawn": "7.0.6", "diff": "8.0.4", "glob": "13.0.6", "highlight.js": "10.7.3", "hosted-git-info": "9.0.3", "ignore": "7.0.5", "jiti": "2.7.0", "minimatch": "10.2.5", "proper-lockfile": "4.1.2", "semver": "7.8.0", "typebox": "1.1.38", "undici": "8.5.0", "yaml": "2.9.0" }, "optionalDependencies": { "@mariozechner/clipboard": "0.3.9" }, "bin": { "pi": "dist/cli.js" } }, "sha512-m9v7OUit0s9LklWfh61ca/XY5INjUzjtYtNZwy3cNvyjOLk3IpBgghP8aAp0iH35rLaiRwuuWiJ8t88ODMWY+A=="],
 
-    "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.79.10", "", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "18.0.5" } }, "sha512-FUVOjDn1DVwM1uHD5MNYboXQrXjIDbSt+BQ3py7nQWCY62tKfxgiM1OBMxTcwRWLfSdZHUPpV0hm1loIdUJnPw=="],
+    "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.80.2", "", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "18.0.5" } }, "sha512-OvOAMIbXiC9OSse17YMiXIsI9AS5XM/ZV8N/k+UzdlRpPILDQYmLElevgGW92kkXR8qHBClIdzhCjuzlBGvphA=="],
 
     "@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -10,9 +10,9 @@
       "license": "MIT",
       "dependencies": {
         "@earendil-works/gondolin": "0.12.0",
-        "@earendil-works/pi-ai": "0.79.10",
-        "@earendil-works/pi-coding-agent": "0.79.10",
-        "@earendil-works/pi-tui": "0.79.10",
+        "@earendil-works/pi-ai": "0.80.2",
+        "@earendil-works/pi-coding-agent": "0.80.2",
+        "@earendil-works/pi-tui": "0.80.2",
         "diff-match-patch": "^1.0.5",
         "typebox": "1.1.28",
         "ws": "8.21.0"
@@ -615,9 +615,9 @@
       }
     },
     "node_modules/@earendil-works/pi-ai": {
-      "version": "0.79.10",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.79.10.tgz",
-      "integrity": "sha512-9jR23tOl0BIUdQMn70Gr72xYBpM7Xgl9Lyv7gAnU1USfkNRuYG/f/edLl+n/Dp/RafDW3JI4DF7y/GhgkORuew==",
+      "version": "0.80.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.2.tgz",
+      "integrity": "sha512-5GNKfdrRJ4uZ5Zd9iudoXggi/BbUcKnD/xfRHtdR+7q4vWqPvfx8auFuaT+ewGBVI8K4wj87eigFQ/iCSuy9RQ==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
@@ -646,15 +646,15 @@
       "license": "MIT"
     },
     "node_modules/@earendil-works/pi-coding-agent": {
-      "version": "0.79.10",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.79.10.tgz",
-      "integrity": "sha512-YxaRhmgyDTvLDdGVbe7YzTHV80oL5mX5odg6EhGHz3w5Wu1Ix8DCw7bhtiOBLGQNFRcknia0zPmVWIj30XP1EA==",
+      "version": "0.80.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.2.tgz",
+      "integrity": "sha512-m9v7OUit0s9LklWfh61ca/XY5INjUzjtYtNZwy3cNvyjOLk3IpBgghP8aAp0iH35rLaiRwuuWiJ8t88ODMWY+A==",
       "hasShrinkwrap": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.79.10",
-        "@earendil-works/pi-ai": "^0.79.10",
-        "@earendil-works/pi-tui": "^0.79.10",
+        "@earendil-works/pi-agent-core": "^0.80.2",
+        "@earendil-works/pi-ai": "^0.80.2",
+        "@earendil-works/pi-tui": "^0.80.2",
         "@silvia-odwyer/photon-node": "0.3.4",
         "chalk": "5.6.2",
         "cross-spawn": "7.0.6",
@@ -1117,11 +1117,11 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.79.10",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.79.10.tgz",
+      "version": "0.80.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.2.tgz",
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.79.10",
+        "@earendil-works/pi-ai": "^0.80.2",
         "ignore": "7.0.5",
         "typebox": "1.1.38",
         "yaml": "2.9.0"
@@ -1131,8 +1131,8 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
-      "version": "0.79.10",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.79.10.tgz",
+      "version": "0.80.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.2.tgz",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
@@ -1148,15 +1148,15 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "./dist/cli.js"
+        "pi-ai": "dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
-      "version": "0.79.10",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.79.10.tgz",
+      "version": "0.80.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.2.tgz",
       "license": "MIT",
       "dependencies": {
         "get-east-asian-width": "1.6.0",
@@ -1264,9 +1264,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1282,9 +1279,6 @@
       "integrity": "sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1302,9 +1296,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1321,9 +1312,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1339,9 +1327,6 @@
       "integrity": "sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2479,9 +2464,9 @@
       }
     },
     "node_modules/@earendil-works/pi-tui": {
-      "version": "0.79.10",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.79.10.tgz",
-      "integrity": "sha512-FUVOjDn1DVwM1uHD5MNYboXQrXjIDbSt+BQ3py7nQWCY62tKfxgiM1OBMxTcwRWLfSdZHUPpV0hm1loIdUJnPw==",
+      "version": "0.80.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.2.tgz",
+      "integrity": "sha512-OvOAMIbXiC9OSse17YMiXIsI9AS5XM/ZV8N/k+UzdlRpPILDQYmLElevgGW92kkXR8qHBClIdzhCjuzlBGvphA==",
       "license": "MIT",
       "dependencies": {
         "get-east-asian-width": "1.6.0",
@@ -3851,9 +3836,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3871,9 +3853,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3891,9 +3870,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3911,9 +3887,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3931,9 +3904,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3951,9 +3921,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/server/package.json
+++ b/server/package.json
@@ -86,9 +86,9 @@
   },
   "dependencies": {
     "@earendil-works/gondolin": "0.12.0",
-    "@earendil-works/pi-ai": "0.79.10",
-    "@earendil-works/pi-coding-agent": "0.79.10",
-    "@earendil-works/pi-tui": "0.79.10",
+    "@earendil-works/pi-ai": "0.80.2",
+    "@earendil-works/pi-coding-agent": "0.80.2",
+    "@earendil-works/pi-tui": "0.80.2",
     "diff-match-patch": "^1.0.5",
     "typebox": "1.1.28",
     "ws": "8.21.0"

--- a/server/src/session-title-generator.ts
+++ b/server/src/session-title-generator.ts
@@ -6,7 +6,7 @@
  * conversation history.
  */
 
-import { completeSimple } from "@earendil-works/pi-ai";
+import { completeSimple } from "@earendil-works/pi-ai/compat";
 import type { ModelRegistry } from "@earendil-works/pi-coding-agent";
 import type { Api, Model } from "@earendil-works/pi-ai";
 

--- a/server/src/token-usage.ts
+++ b/server/src/token-usage.ts
@@ -1,4 +1,5 @@
-import { calculateCost, getModel, type KnownProvider, type Usage } from "@earendil-works/pi-ai";
+import { calculateCost, type KnownProvider, type Usage } from "@earendil-works/pi-ai";
+import { getModel } from "@earendil-works/pi-ai/compat";
 import type { PiMessageUsage } from "./pi-events.js";
 
 export interface NormalizedUsage {

--- a/server/tests/session-title-generator.test.ts
+++ b/server/tests/session-title-generator.test.ts
@@ -2,9 +2,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockCompleteSimple = vi.hoisted(() => vi.fn());
 
-vi.mock("@earendil-works/pi-ai", async () => {
+vi.mock("@earendil-works/pi-ai/compat", async () => {
   const actual =
-    await vi.importActual<typeof import("@earendil-works/pi-ai")>("@earendil-works/pi-ai");
+    await vi.importActual<typeof import("@earendil-works/pi-ai/compat")>("@earendil-works/pi-ai/compat");
   return {
     ...actual,
     completeSimple: mockCompleteSimple,


### PR DESCRIPTION
## What & why

Closes #11.

oppi-server 0.42.0 is pinned to `@earendil-works/pi-ai` / `pi-coding-agent` / `pi-tui` **0.79.10**. As of `pi-coding-agent 0.80.0`, `pi-ai`'s old global API (`getModel`, `completeSimple`, `complete`, `stream`, the api-registry helpers, …) moved from the root entrypoint to `@earendil-works/pi-ai/compat`, and the root became core-only / side-effect free.

Concrete impact under 0.79.10: a Pi extension that imports `@earendil-works/pi-ai/compat` (e.g. the popular `pi-web-access` package, which registers `web_search` / `fetch_content`) fails to load, so its tools never register with the LLM. There's no user-visible error — the tool just disappears (the extension's *skill* still loads, which makes it look like a forwarding problem). See #11 for the `dist/index.js/compat` jiti resolution trace. The same extension works under standalone `pi 0.80.2`.

This PR bumps to **0.80.2** (which has the `./compat` subpath and the loader alias natively) and migrates the two moved runtime symbols oppi imports to `…/compat`.

## Changes

- `package.json`: `@earendil-works/pi-ai` / `pi-coding-agent` / `pi-tui` `0.79.10` → `0.80.2`.
- `src/token-usage.ts`: `getModel` moved to `@earendil-works/pi-ai/compat` (split import; `calculateCost`, `KnownProvider`, `Usage` stay on root — still exported there).
- `src/session-title-generator.ts`: `completeSimple` moved to `@earendil-works/pi-ai/compat`.
- `tests/session-title-generator.test.ts`: the `vi.mock("@earendil-works/pi-ai", …)` retargeted to `@earendil-works/pi-ai/compat` so the mock still intercepts `completeSimple`.
- `package-lock.json` and `bun.lock` regenerated (`npm install --package-lock-only`; `bun install --lockfile-only`). `ignore-scripts=true` / `save-exact=true` in `.npmrc` honored.

### Why not blanket-switch every `@earendil-works/pi-ai` import to compat
Keeping the diff surgical: only the symbols that actually moved (`getModel`, `completeSimple`) go to `compat`. The remaining root imports are for symbols that did NOT move and are still on root:
- `src/session-title-generator.ts` (`Api`, `Model`), `src/sdk-backend.ts` (`ImageContent`), `src/token-usage.ts` (`calculateCost`, `KnownProvider`, `Usage`), `src/provider-auth/provider-auth-manager.ts` (`OAuthLoginCallbacks`, `OAuthProviderInterface`) — all still re-exported by root via `export * from "./types.js"` / `./models.js` / `index.d.ts`.
`compat` is a strict superset of root (`compat.d.ts` does `export * from "./index.ts"`), and `pi-coding-agent 0.80.x` itself imports from compat, so importing compat adds no new side effects. I still kept the migration minimal to make review easier.

### Call-signature compatibility (verified against 0.80.2 .d.ts)
- `getModel(provider, modelId)` — compat re-exports `getModel` as `typeof getBuiltinModel`; the existing call site already passes `(provider, modelId)` with an `as never` cast. ✓
- `completeSimple(model, context, options?)` — identical signature in `compat.d.ts`. ✓

## Verification done
- `bun install` (real install, `--frozen-lockfile` ok) succeeds; `node_modules` resolves to pi-ai/coding-agent/tui 0.80.2 with the native `./compat` subpath — no monkey-patch needed.
- **`bun run check` passes clean** (tsc --noEmit + eslint + knip + prettier + architecture boundaries) — verified on macOS after this branch was prepared on a memory-constrained Raspberry Pi. This directly exercises the import-path edits in this PR.
- Both lockfiles resolve cleanly (421 packages via bun, full npm tree) with no version conflicts.
- Confirmed moved vs. stationary symbols against the 0.80.2 declaration files (`compat.d.ts`, `index.js`, `types.d.ts`).
- Confirmed the parallel breaking changes in pi-coding-agent 0.80.0 do **not** touch oppi: no reference to the renamed `ExecutionEnvExecOptions` → `ShellExecOptions` type in `src/`, and no custom Anthropic-compat model definitions.
- Confirmed the original bug is fixed by the bump alone: running the fork's bundled 0.80.2 `pi-coding-agent` CLI against a `pi-web-access` install lists `web_search` / `fetch_content` / `get_search_content` without any loader patch — i.e. this PR is sufficient, no `loader.js` edit needed upstream (the local workaround in #11 only re-adds the alias that 0.80.x already ships).

## Verification **not** done
A full `bun test` suite was not run end-to-end locally due to environment constraints. The two test files touched by this PR's source changes are `tests/session-title-generator.test.ts` (retargeted `vi.mock` to `@earendil-works/pi-ai/compat`) and `tests/token-usage.test.ts` (no mock of pi-ai, so unaffected by the move). **Please run CI (`bun test`).** Happy to address anything it surfaces.

(Note: one currently-failing test was observed to fail identically on `main`, so it is pre-existing and unrelated to this PR.)

## After merge
Once oppi ships a build with pi-coding-agent ≥ 0.80.0, the local monkey-patch workaround described in #11 (`oppi-patch-pi-ai-compat.mjs`) can be deleted — pi-web-access and any other `…/pi-ai/compat` extension will load unmodified.