### PR TITLE
docs(agents): add Cursor Cloud environment and server test instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,24 @@ cd server && npm run test:gate:pr-fast
 # Apple
 cd clients/apple && xcodegen generate
 cd clients/apple && ./scripts/sim-pool.sh \
-  run -- xcodebuild -project Oppi.xcodeproj -scheme Oppi build
+ run -- xcodebuild -project Oppi.xcodeproj -scheme Oppi build
 cd clients/apple && ./scripts/sim-pool.sh \
-  run -- xcodebuild -project Oppi.xcodeproj -scheme OppiUnitTests test -only-testing:OppiTests
+ run -- xcodebuild -project Oppi.xcodeproj -scheme OppiUnitTests test -only-testing:OppiTests
+```
+
+## Cursor Cloud specific instructions
+
+The Cloud Agent VM is Linux, so only the `server/` workspace runs here; the Apple client needs macOS and Xcode. The base image ships Node 22 as the default `node`, but the server requires Node 24+ (`engines.node >=24`). Node 24 and Bun are installed via `nvm`/`~/.bun`; a login shell (or sourcing `~/.nvm/nvm.sh` and using the default alias) selects Node 24.
+
+Two platform-injected settings make the server suite fail unless neutralized per invocation:
+
+- `NO_COLOR=1` / `TERM=dumb` disable ANSI output, breaking CLI tests that assert on color escapes.
+- The managed global git config forces `commit.gpgsign=true` with an SSH signer that intermittently stalls for 20+ seconds, so git-heavy tests (worktrees, workspace git diff) exceed the 10s test timeout.
+
+Run the server checks and tests like this (leaves the managed git config untouched for your own signed commits):
+
+```bash
+cd server
+env -u NO_COLOR -u FORCE_COLOR GIT_CONFIG_GLOBAL=/dev/null npm run check
+env -u NO_COLOR -u FORCE_COLOR GIT_CONFIG_GLOBAL=/dev/null npm test
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,7 @@ cd clients/apple && ./scripts/sim-pool.sh \
 
 ## Cursor Cloud specific instructions
 
-The Cloud Agent VM is Linux, so only the `server/` workspace runs here; the Apple client needs macOS and Xcode. The base image ships Node 22 as the default `node`, but the server requires Node 24+ (`engines.node >=24`). Node 24 and Bun are installed via `nvm`/`~/.bun`; a login shell (or sourcing `~/.nvm/nvm.sh` and using the default alias) selects Node 24.
+The Cloud Agent VM is Linux, so only the `server/` workspace runs here; the Apple client needs macOS and Xcode. The server requires Node 24+ (`engines.node >=24`). The environment makes `node`, `npm`, `npx`, and `bun` resolve to the correct versions in every shell (Node 24 shadows the platform's Node 22 shim), so plain `node`/`npm` commands and the built `oppi` CLI work without sourcing anything.
 
 Two platform-injected settings make the server suite fail unless neutralized per invocation:
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` capturing the non-obvious operating knowledge discovered while setting up a Cloud Agent development environment for this repo.

## Why

The Cloud Agent VM is Linux, so only `server/` is runnable there (the Apple client needs macOS/Xcode). Two platform-injected settings otherwise make the server suite fail, and the base image's default `node` is v22 while the server requires Node 24+:

- `NO_COLOR=1` / `TERM=dumb` disable ANSI output, breaking CLI runner tests that assert on color escape codes.
- The managed global git config forces `commit.gpgsign=true` with an SSH signer that intermittently stalls 20+ seconds, so git-heavy tests (worktrees, workspace git diff) blow past the 10s test timeout.

With `env -u NO_COLOR -u FORCE_COLOR GIT_CONFIG_GLOBAL=/dev/null` the full server suite passes (229 files, 3793 tests, 0 failures). Neutralizing `GIT_CONFIG_GLOBAL` only for the test invocation leaves the managed git config intact for the agent's own signed commits.

## Notes

- No application code or test/config files are changed; this is documentation only.
- The environment toolchain (Node 24 via nvm, Bun) and install/start scripts are configured separately in the Cloud Agent environment settings (proposed for Save via the dashboard), not committed here.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b9991986-71c9-4c7a-93cc-606e74cf4727?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b9991986-71c9-4c7a-93cc-606e74cf4727&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

