### PR TITLE
docs: record published oppi-server and oppi-mirror 0.47.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,14 @@ Example:
 
 ## [Unreleased]
 
-Target: iOS `1.1.1` build `46`, unpublished `oppi-server@0.47.0` with bundled Pi runtime `0.84.2`, and unpublished `oppi-mirror@0.47.0`.
+## [0.47.0] - 2026-08-20
+
+Target: iOS `1.1.1` build `46`, `oppi-server@0.47.0` with bundled Pi runtime `0.84.2`, and `oppi-mirror@0.47.0`.
+
+### Notes
+
+- Published npm `oppi-server@0.47.0` and `oppi-mirror@0.47.0` from `ff4c989f`.
+- iOS `1.1.1` build `46` remains the coordinated client target.
 
 ### Added
 
@@ -67,6 +74,11 @@ Target: iOS `1.1.1` build `46`, unpublished `oppi-server@0.47.0` with bundled Pi
 ### Removed
 
 - **Client/Server:** Iroh pairing and the public `piSessionId` dual-ID path.
+
+### Migration notes
+
+- **Server:** Update npm installs with `npm install -g oppi-server@0.47.0`. App-managed runtimes update through the Oppi app bundle, not `oppi update`.
+- **Mirror extension:** Install or refresh `oppi-mirror@0.47.0`, then use `/reload` in any already-running interactive Pi session.
 
 ## [0.46.0] - 2026-08-10
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
npm `oppi-server@0.47.0` and `oppi-mirror@0.47.0` are now `latest` on the public registry, published from `ff4c989f`.

This PR only updates `CHANGELOG.md`:
- Moves the coordinated 0.47.0 notes out of Unreleased
- Drops the "unpublished" markers
- Adds install/reload migration notes

## Publish evidence
- Registry `latest`: `0.47.0` for both packages
- `gitHead` on both tarballs: `ff4c989f62990a5a849879af058a360ca1056031`
- Pre-publish gates: Pi `0.84.2` match, mirror `check:release` (25 tests), server `check`, server tests 3793 passed / 7 skipped

iOS TestFlight build 46 was not part of this npm publish.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-208313ee-ef14-4cf2-88ad-b3643a1be2d3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-208313ee-ef14-4cf2-88ad-b3643a1be2d3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

