### PR TITLE
chore: bump oppi-server and oppi-mirror to 0.47.2

### DIFF
--- a/pi-extensions/oppi-mirror/package.json
+++ b/pi-extensions/oppi-mirror/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oppi-mirror",
-  "version": "0.47.0",
+  "version": "0.47.1",
   "description": "Pi extension for mirroring live terminal sessions into Oppi.",
   "type": "module",
   "license": "MIT",

--- a/pi-extensions/oppi-mirror/package.json
+++ b/pi-extensions/oppi-mirror/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oppi-mirror",
-  "version": "0.47.1",
+  "version": "0.47.2",
   "description": "Pi extension for mirroring live terminal sessions into Oppi.",
   "type": "module",
   "license": "MIT",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oppi-server",
-  "version": "0.47.0",
+  "version": "0.47.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oppi-server",
-      "version": "0.47.0",
+      "version": "0.47.1",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/gondolin": "0.12.0",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oppi-server",
-  "version": "0.47.1",
+  "version": "0.47.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oppi-server",
-      "version": "0.47.1",
+      "version": "0.47.2",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/gondolin": "0.12.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oppi-server",
-  "version": "0.47.1",
+  "version": "0.47.2",
   "description": "Self-hosted server for the Oppi mobile coding agent",
   "type": "module",
   "main": "dist/src/cli.js",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oppi-server",
-  "version": "0.47.0",
+  "version": "0.47.1",
   "description": "Self-hosted server for the Oppi mobile coding agent",
   "type": "module",
   "main": "dist/src/cli.js",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`oppi-server@0.47.1` is on npm but was packed from a stale `dist` (missing current HEAD files). npm cannot overwrite that version.

This branch bumps both packages to `0.47.2` so current `main` can publish a rebuilt tarball. No changelog edits.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-208313ee-ef14-4cf2-88ad-b3643a1be2d3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-208313ee-ef14-4cf2-88ad-b3643a1be2d3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

