### PR TITLE
fix: route tree navigation through command context

### DIFF
--- a/pi-extensions/oppi-mirror/extensions/oppi-mirror.test.ts
+++ b/pi-extensions/oppi-mirror/extensions/oppi-mirror.test.ts
@@ -205,6 +205,7 @@ interface MockExtensionContext {
   hasPendingMessages: ReturnType<typeof vi.fn>;
   abort: ReturnType<typeof vi.fn>;
   shutdown: ReturnType<typeof vi.fn>;
+  navigateTree?: ReturnType<typeof vi.fn>;
   ui: {
     theme: { fg: ReturnType<typeof vi.fn> };
     setWidget: ReturnType<typeof vi.fn>;
@@ -734,6 +735,237 @@ describe("oppi mirror input preflight", () => {
 
       expect(agentSession.promptCalls).toHaveLength(6);
       expect(pi.sendUserMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  it("routes remote tree navigation through the terminal command context", async () => {
+    await withInteractiveTerminal(async () => {
+      vi.stubEnv("OPPI_MIRROR_URL", "http://127.0.0.1:1234");
+      vi.stubEnv("OPPI_MIRROR_TOKEN", "test-token");
+      vi.stubEnv("OPPI_MIRROR_AUTO_START", "false");
+      const pi = createMockPi();
+      await oppiPiMirror(pi as never);
+      const ctx = createMockContext();
+      await startSession(pi, ctx);
+      const agentSession = new piAgentMock.FakeAgentSession();
+      agentSession.bindExtensions();
+      const navigateTree = vi.fn(async () => ({ cancelled: false }));
+      pi.sendUserMessage.mockImplementation((text: string) => {
+        const args = text.replace(/^\/oppi-mirror\s*/, "");
+        void pi.commands
+          .get("oppi-mirror")
+          ?.handler(args, { ...ctx, navigateTree });
+      });
+      const socket = await startMirror(pi, ctx);
+      socket.sent.length = 0;
+
+      socket.receive(
+        JSON.stringify({
+          type: "command",
+          id: "navigate-tree-terminal-sync",
+          command: {
+            type: "navigate_tree",
+            targetId: "entry-1",
+            summarize: false,
+          },
+        }),
+      );
+      await drainMicrotasks();
+
+      expect(navigateTree).toHaveBeenCalledWith("entry-1", {
+        summarize: false,
+        customInstructions: undefined,
+        replaceInstructions: undefined,
+        label: undefined,
+      });
+      expect(pi.sendUserMessage).toHaveBeenCalledWith(
+        expect.stringMatching(
+          /^\/oppi-mirror __navigate-tree [0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+        ),
+        { expandPromptTemplates: true },
+      );
+      expect(sentCommandResults(socket, "navigate-tree-terminal-sync")).toEqual(
+        [
+          expect.objectContaining({
+            success: true,
+            data: { cancelled: false },
+          }),
+        ],
+      );
+    });
+  });
+
+  it("rejects concurrent remote tree navigation", async () => {
+    await withInteractiveTerminal(async () => {
+      vi.stubEnv("OPPI_MIRROR_URL", "http://127.0.0.1:1234");
+      vi.stubEnv("OPPI_MIRROR_TOKEN", "test-token");
+      vi.stubEnv("OPPI_MIRROR_AUTO_START", "false");
+      const pi = createMockPi();
+      await oppiPiMirror(pi as never);
+      const ctx = createMockContext();
+      await startSession(pi, ctx);
+      const socket = await startMirror(pi, ctx);
+      socket.sent.length = 0;
+
+      for (const [id, targetId] of [
+        ["navigate-first", "entry-1"],
+        ["navigate-second", "entry-2"],
+      ]) {
+        socket.receive(
+          JSON.stringify({
+            type: "command",
+            id,
+            command: { type: "navigate_tree", targetId },
+          }),
+        );
+      }
+      await drainMicrotasks();
+
+      expect(pi.sendUserMessage).toHaveBeenCalledTimes(1);
+      expect(sentCommandResults(socket, "navigate-second")).toEqual([
+        expect.objectContaining({
+          success: false,
+          error: "A session-tree navigation is already in progress.",
+        }),
+      ]);
+
+      await pi.commands.get("oppi-mirror")?.handler("stop", ctx);
+      await drainMicrotasks();
+    });
+  });
+
+  it("rejects tree navigation if Pi becomes busy before command dispatch", async () => {
+    await withInteractiveTerminal(async () => {
+      vi.stubEnv("OPPI_MIRROR_URL", "http://127.0.0.1:1234");
+      vi.stubEnv("OPPI_MIRROR_TOKEN", "test-token");
+      vi.stubEnv("OPPI_MIRROR_AUTO_START", "false");
+      const pi = createMockPi();
+      await oppiPiMirror(pi as never);
+      const ctx = createMockContext();
+      await startSession(pi, ctx);
+      const socket = await startMirror(pi, ctx);
+      socket.sent.length = 0;
+
+      socket.receive(
+        JSON.stringify({
+          type: "command",
+          id: "navigate-became-busy",
+          command: { type: "navigate_tree", targetId: "entry-1" },
+        }),
+      );
+      await drainMicrotasks();
+      const dispatched = pi.sendUserMessage.mock.calls[0]?.[0];
+      expect(dispatched).toEqual(expect.any(String));
+      ctx.isIdle.mockReturnValue(false);
+      const navigateTree = vi.fn();
+      await pi.commands
+        .get("oppi-mirror")
+        ?.handler(String(dispatched).replace(/^\/oppi-mirror\s*/, ""), {
+          ...ctx,
+          navigateTree,
+        });
+      await drainMicrotasks();
+
+      expect(navigateTree).not.toHaveBeenCalled();
+      expect(sentCommandResults(socket, "navigate-became-busy")).toEqual([
+        expect.objectContaining({
+          success: false,
+          error:
+            "Wait for the current response to finish before navigating the session tree.",
+        }),
+      ]);
+    });
+  });
+
+  it("keeps the navigation lock across mirror stop and restart", async () => {
+    await withInteractiveTerminal(async () => {
+      vi.stubEnv("OPPI_MIRROR_URL", "http://127.0.0.1:1234");
+      vi.stubEnv("OPPI_MIRROR_TOKEN", "test-token");
+      vi.stubEnv("OPPI_MIRROR_AUTO_START", "false");
+      const pi = createMockPi();
+      await oppiPiMirror(pi as never);
+      const ctx = createMockContext();
+      await startSession(pi, ctx);
+      let finishNavigation = () => {};
+      const navigateTree = vi.fn(
+        () =>
+          new Promise<{ cancelled: false }>((resolve) => {
+            finishNavigation = () => resolve({ cancelled: false });
+          }),
+      );
+      const commandContext = { ...ctx, navigateTree };
+      pi.sendUserMessage.mockImplementation((text: string) => {
+        void pi.commands
+          .get("oppi-mirror")
+          ?.handler(text.replace(/^\/oppi-mirror\s*/, ""), commandContext);
+      });
+      const firstSocket = await startMirror(pi, ctx);
+
+      firstSocket.receive(
+        JSON.stringify({
+          type: "command",
+          id: "navigate-before-stop",
+          command: { type: "navigate_tree", targetId: "entry-1" },
+        }),
+      );
+      await drainMicrotasks();
+      expect(navigateTree).toHaveBeenCalledTimes(1);
+
+      await pi.commands.get("oppi-mirror")?.handler("stop", ctx);
+      const secondSocket = await startMirror(pi, ctx);
+      secondSocket.sent.length = 0;
+      secondSocket.receive(
+        JSON.stringify({
+          type: "command",
+          id: "navigate-after-restart",
+          command: { type: "navigate_tree", targetId: "entry-2" },
+        }),
+      );
+      await drainMicrotasks();
+
+      expect(
+        sentCommandResults(secondSocket, "navigate-after-restart"),
+      ).toEqual([
+        expect.objectContaining({
+          success: false,
+          error: "A session-tree navigation is already in progress.",
+        }),
+      ]);
+      expect(navigateTree).toHaveBeenCalledTimes(1);
+
+      finishNavigation();
+      await drainMicrotasks();
+    });
+  });
+
+  it("fails a remote tree navigation when Pi does not dispatch its command", async () => {
+    await withInteractiveTerminal(async () => {
+      vi.useFakeTimers();
+      vi.stubEnv("OPPI_MIRROR_URL", "http://127.0.0.1:1234");
+      vi.stubEnv("OPPI_MIRROR_TOKEN", "test-token");
+      vi.stubEnv("OPPI_MIRROR_AUTO_START", "false");
+      const pi = createMockPi();
+      await oppiPiMirror(pi as never);
+      const ctx = createMockContext();
+      await startSession(pi, ctx);
+      const socket = await startMirror(pi, ctx);
+      socket.sent.length = 0;
+
+      socket.receive(
+        JSON.stringify({
+          type: "command",
+          id: "navigate-not-dispatched",
+          command: { type: "navigate_tree", targetId: "entry-1" },
+        }),
+      );
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      expect(sentCommandResults(socket, "navigate-not-dispatched")).toEqual([
+        expect.objectContaining({
+          success: false,
+          error: "Pi did not start the session-tree navigation command",
+        }),
+      ]);
     });
   });
 

--- a/pi-extensions/oppi-mirror/extensions/oppi-mirror.ts
+++ b/pi-extensions/oppi-mirror/extensions/oppi-mirror.ts
@@ -9,7 +9,7 @@ import {
   type ToolRenderResultOptions,
 } from "@earendil-works/pi-coding-agent";
 import { WebSocket, type RawData } from "ws";
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { appendFileSync, mkdirSync, readFileSync } from "node:fs";
 import { basename, dirname, join, resolve } from "node:path";
 import { hostname } from "node:os";
@@ -144,15 +144,21 @@ interface EditableAgentSession {
     ReturnType<ExtensionAPI["getThinkingLevel"]>
   >;
   getUserMessagesForForking?: () => Array<{ entryId: string; text: string }>;
-  navigateTree?: (
-    targetId: string,
-    options?: {
-      summarize?: boolean;
-      customInstructions?: string;
-      replaceInstructions?: boolean;
-      label?: string;
-    },
-  ) => Promise<unknown>;
+}
+
+interface MirrorTreeNavigationOptions {
+  summarize?: boolean;
+  customInstructions?: string;
+  replaceInstructions?: boolean;
+  label?: string;
+}
+
+interface PendingTreeNavigation {
+  targetId: string;
+  options: MirrorTreeNavigationOptions;
+  dispatchTimer: ReturnType<typeof setTimeout>;
+  resolve: (result: unknown) => void;
+  reject: (error: unknown) => void;
 }
 
 interface QueueUpdateEvent {
@@ -2861,6 +2867,8 @@ async function createTuiMirrorRuntime(
   >();
   const pendingUIRequestPayloads = new Map<string, Record<string, unknown>>();
   const pendingUISettledIds = new Set<string>();
+  const pendingTreeNavigations = new Map<string, PendingTreeNavigation>();
+  let activeTreeNavigationToken: string | null = null;
   const terminalDialogQueue = createMirrorTerminalDialogQueue();
   const toolArgsByCallId = new Map<string, Record<string, unknown>>();
   const proxiedUIContexts = new WeakSet<object>();
@@ -2949,9 +2957,20 @@ async function createTuiMirrorRuntime(
     );
   }
 
+  function rejectPendingTreeNavigations(reason: string): void {
+    for (const pending of pendingTreeNavigations.values()) {
+      clearTimeout(pending.dispatchTimer);
+      pending.reject(new Error(reason));
+    }
+    pendingTreeNavigations.clear();
+  }
+
   function deactivateAfterStaleContext(scope: string) {
     if (!runtimeActive && !ws && !reconnectTimer && !heartbeatTimer) return;
     runtimeActive = false;
+    rejectPendingTreeNavigations(
+      "Oppi Mirror deactivated during tree navigation",
+    );
     manualStop = true;
     connectionSerial += 1;
     clearTimers();
@@ -4518,6 +4537,7 @@ async function createTuiMirrorRuntime(
     pendingUIResponses.clear();
     pendingUIRequestPayloads.clear();
     pendingUISettledIds.clear();
+    rejectPendingTreeNavigations("Oppi Mirror stopped during tree navigation");
     const socket = ws;
     const stateCtx = ctx ?? latestCtx;
     if (socket?.readyState === WebSocket.OPEN) {
@@ -4962,12 +4982,15 @@ async function createTuiMirrorRuntime(
       case "navigate_tree": {
         const targetId = String(command.targetId ?? "").trim();
         if (!targetId) throw new Error("Invalid payload: expected targetId");
-        const navigateTree = requireEditableAgentSession(ctx).navigateTree;
-        if (!navigateTree)
+        if (!ctx.isIdle()) {
           throw new Error(
-            "Terminal Pi runtime tree navigation is not attached yet",
+            "Wait for the current response to finish before navigating the session tree.",
           );
-        return await navigateTree(targetId, {
+        }
+        if (activeTreeNavigationToken || pendingTreeNavigations.size > 0) {
+          throw new Error("A session-tree navigation is already in progress.");
+        }
+        const options: MirrorTreeNavigationOptions = {
           summarize:
             typeof command.summarize === "boolean"
               ? command.summarize
@@ -4981,6 +5004,33 @@ async function createTuiMirrorRuntime(
               ? command.replaceInstructions
               : undefined,
           label: typeof command.label === "string" ? command.label : undefined,
+        };
+        const token = randomUUID();
+        return await new Promise((resolve, reject) => {
+          const dispatchTimer = setTimeout(() => {
+            const pending = pendingTreeNavigations.get(token);
+            if (!pending || activeTreeNavigationToken === token) return;
+            pendingTreeNavigations.delete(token);
+            pending.reject(
+              new Error("Pi did not start the session-tree navigation command"),
+            );
+          }, 10_000);
+          pendingTreeNavigations.set(token, {
+            targetId,
+            options,
+            dispatchTimer,
+            resolve,
+            reject,
+          });
+          try {
+            pi.sendUserMessage(`/oppi-mirror __navigate-tree ${token}`, {
+              expandPromptTemplates: true,
+            });
+          } catch (error) {
+            clearTimeout(dispatchTimer);
+            pendingTreeNavigations.delete(token);
+            reject(error);
+          }
         });
       }
 
@@ -5343,7 +5393,7 @@ async function createTuiMirrorRuntime(
     description: "Mirror this live Pi TUI session into Oppi",
     handler: async (args, ctx) => {
       try {
-        const [subcommand] = args.trim().split(/\s+/).filter(Boolean);
+        const [subcommand, token] = args.trim().split(/\s+/).filter(Boolean);
         switch (subcommand || "status") {
           case "start":
             connect(ctx);
@@ -5360,6 +5410,43 @@ async function createTuiMirrorRuntime(
               ws?.readyState === WebSocket.OPEN ? "info" : "warning",
             );
             return;
+          case "__navigate-tree": {
+            const pending = token
+              ? pendingTreeNavigations.get(token)
+              : undefined;
+            if (!pending || activeTreeNavigationToken === token) return;
+            if (activeTreeNavigationToken) {
+              clearTimeout(pending.dispatchTimer);
+              pendingTreeNavigations.delete(token);
+              pending.reject(
+                new Error("A session-tree navigation is already in progress."),
+              );
+              return;
+            }
+            if (!ctx.isIdle()) {
+              clearTimeout(pending.dispatchTimer);
+              pendingTreeNavigations.delete(token);
+              pending.reject(
+                new Error(
+                  "Wait for the current response to finish before navigating the session tree.",
+                ),
+              );
+              return;
+            }
+            activeTreeNavigationToken = token;
+            clearTimeout(pending.dispatchTimer);
+            try {
+              pending.resolve(
+                await ctx.navigateTree(pending.targetId, pending.options),
+              );
+            } catch (error) {
+              pending.reject(error);
+            } finally {
+              pendingTreeNavigations.delete(token);
+              activeTreeNavigationToken = null;
+            }
+            return;
+          }
           default:
             notify(ctx, "Usage: /oppi-mirror start|stop|status", "warning");
         }


### PR DESCRIPTION
Closes #30.

## Summary

- Route remote tree navigation through Pi's command context so the terminal redraws the selected branch
- Reject concurrent or late navigation requests and clean them up when the mirror stops
- Use a random internal dispatch token so another prompt cannot predict it

## Why

The mirror called the underlying session navigation method directly. That could bypass Pi's interactive command lifecycle, leave the terminal transcript on the previous branch, or disconnect the mirror.

## Verification

- `oppi-mirror` release check passed with 39 tests
- Server checks passed
- Live-tested branch switching from an iPhone, terminal transcript updates, and messages in both directions without a crash or disconnect